### PR TITLE
Fix assassin targeting rules

### DIFF
--- a/lib/cinch/plugins/resistance_game.rb
+++ b/lib/cinch/plugins/resistance_game.rb
@@ -662,9 +662,25 @@ module Cinch
         if @game.is_over? && @game.current_round.in_assassinate_phase?
           if @game.find_player_by_role(:assassin).user == m.user
             killed = @game.find_player(target)
+
+            # We don't let the Assassin kill a spy known to him.
+            # An Oberon/Assassin can kill anyone.
+            # A non-Oberon Assassin can kill any Resistance member, or Oberon.
+            #
+            # If Lancelots are in play and switch once:
+            # Spies know NOT to kill original Evil Lance: he can't be Merlin.
+            # They don't know who original Good Lance is, so he IS a target
+            # for the kill.
+            # Therefore, we to check a player's ORIGINAL allegiance.
+            #
+            # Finally, current code does not allow for Lancelot assassins,
+            # so we avoid that hairy issue. Lancelot3/Assassin could work, but
+            # is not implemented either for simplicity.
+
+            assassin_is_oberon = @game.assassin_dual == :oberon
             if killed.nil?
               User(m.user).send "\"#{target}\" is an invalid target."
-            elsif killed.spy?
+            elsif killed.original_spy? && !assassin_is_oberon && !killed.role?(:oberon)
               User(m.user).send "\"#{target}\" is not a member of the resistance"
             else
               spies, resistance = get_loyalty_info


### PR DESCRIPTION
Before this patch, the Assassin can kill any Resistance member, and is
prevented from killing any Spy.
But this is sometimes incorrect behavior.

Only the Assassin's may reveal during the assassination phase.
This means that Oberon is not known to him for sure, and Oberon is thus
a valid target for assassination.
If Lancelots have switched once, Assassin is not going to kill Evil
Lance, but he doesn't know Good Lance (who is now on his side). So Good
Lance is a valid target.
Therefore, we check ORIGINAL allegiance, not current allegiance.

Finally, Oberon/Assassin can kill anyone!!!
