### PR TITLE
process_mission_votes: Lock decisions

### DIFF
--- a/lib/cinch/plugins/core/round.rb
+++ b/lib/cinch/plugins/core/round.rb
@@ -160,6 +160,10 @@ class Round
     self.state = :lady
   end
 
+  def lock_decisions
+    self.state = :decisions_locked
+  end
+
   def end_round
     self.state = :end
   end

--- a/lib/cinch/plugins/resistance_game.rb
+++ b/lib/cinch/plugins/resistance_game.rb
@@ -1039,6 +1039,10 @@ module Cinch
       end
 
       def process_mission_votes
+        # Since we pause while revealing results, we enter a "lock decisions" phase
+        # so that players do not send extra commands and break the game.
+        @game.current_round.lock_decisions
+
         # reveal the results
         Channel(@channel_name).send "The team is back from the mission..."
         @game.current_round.mission_votes.values.sort.reverse.each do |vote|


### PR DESCRIPTION
Otherwise, a player may send an extra !mission or !excalibur or !sheath
and break the game (by causing the round to count twice).

Fixes #6
